### PR TITLE
Fixed minor bugs regarding the save-intermediate feature

### DIFF
--- a/cellstates/run.py
+++ b/cellstates/run.py
@@ -35,11 +35,10 @@ def run_mcmc(clst, results_dir=None, N_steps=10000, tries_per_step=1000, min_ind
 
     logging.debug(f'initially check output every {N_steps} steps')
 
-    cluster_file = os.path.join(results_dir, 'intermediate_clusters.txt')
-
     i = 0
     # save initial configuration
     if results_dir:
+        cluster_file = os.path.join(results_dir, 'intermediate_clusters.txt')
         logging.debug(f'writing intermediate states to directory {results_dir}')
         logging.debug(f'write output {i:04d}')
         if keep_intermediate:

--- a/scripts/run_cellstates.py
+++ b/scripts/run_cellstates.py
@@ -185,7 +185,7 @@ def main():
         intermediate_dir = None
 
     run_mcmc(clst, N_steps=N, log_level=LOG_LEVEL, tries_per_step=TPS,
-             results_dir=intermediate_dir)
+             results_dir=intermediate_dir, keep_intermediate=args.save_intermediate)
 
     # optimise alpha and run MCMC again if needed
     while find_best_alpha:

--- a/scripts/run_cellstates.py
+++ b/scripts/run_cellstates.py
@@ -185,7 +185,7 @@ def main():
         intermediate_dir = None
 
     run_mcmc(clst, N_steps=N, log_level=LOG_LEVEL, tries_per_step=TPS,
-             results_dir=intermediate_dir, keep_intermediate=args.save_intermediate)
+             results_dir=intermediate_dir, keep_intermediate=args.save_intermediates)
 
     # optimise alpha and run MCMC again if needed
     while find_best_alpha:


### PR DESCRIPTION
Made two changes:
- when running without save-intermediate option there was a bug because variable results_dir was used to create cluster_file but results_dir was then None. I fixed that by putting it after if results_dir:
- The argument args.save_intermediates was never passed on to run_mcmc function, such that no intermediate results were stored. 